### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(
             name: "GhostTypewriter",
             targets: ["GhostTypewriter"]
-        ),
+        )
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "GhostTypewriter",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(
+            name: "GhostTypewriter",
+            targets: ["GhostTypewriter"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "GhostTypewriter",
+            path: "GhostTypewriter"
+        ),
+        .testTarget(
+            name: "GhostTypewriterTests",
+            dependencies: ["GhostTypewriter"],
+            path: "GhostTypewriterTests"
+        )
+    ]
+)


### PR DESCRIPTION
Adds `Package.swift` file which enables usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes Package.swift. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.